### PR TITLE
Formatter implementation using delegation (with example on bitfinex).

### DIFF
--- a/bitex/formatters/__init__.py
+++ b/bitex/formatters/__init__.py
@@ -9,4 +9,4 @@ from bitex.formatters.bitfinex import BitfinexFormattedResponse
 # from bitex.formatters.hitbtc import HitBTCFormattedResponse
 # from bitex.formatters.kraken import KrakenFormattedResponse
 # from bitex.formatters.okcoin import OkCoinFormattedResponse
-# from bitex.formatters.poloniex import PoloniexFormattedResponse
+from bitex.formatters.poloniex import PoloniexFormattedResponse

--- a/bitex/formatters/__init__.py
+++ b/bitex/formatters/__init__.py
@@ -1,0 +1,12 @@
+from bitex.formatters.base import AbstractFormattedResponse
+from bitex.formatters.bitfinex import BitfinexFormattedResponse
+# from bitex.formatters.binance import BinanceFormattedResponse
+# from bitex.formatters.bitstamp import BitstampFormattedResponse
+# from bitex.formatters.bittrex import BittrexFormattedResponse
+# from bitex.formatters.ccex import CCEXFormattedResponse
+# from bitex.formatters.coincheck import CoinCheckFormattedResponse
+# from bitex.formatters.cryptopia import CryptopiaFormattedResponse
+# from bitex.formatters.hitbtc import HitBTCFormattedResponse
+# from bitex.formatters.kraken import KrakenFormattedResponse
+# from bitex.formatters.okcoin import OkCoinFormattedResponse
+# from bitex.formatters.poloniex import PoloniexFormattedResponse

--- a/bitex/formatters/__init__.py
+++ b/bitex/formatters/__init__.py
@@ -1,12 +1,12 @@
 from bitex.formatters.base import AbstractFormattedResponse
 from bitex.formatters.bitfinex import BitfinexFormattedResponse
-# from bitex.formatters.binance import BinanceFormattedResponse
-# from bitex.formatters.bitstamp import BitstampFormattedResponse
-# from bitex.formatters.bittrex import BittrexFormattedResponse
-# from bitex.formatters.ccex import CCEXFormattedResponse
-# from bitex.formatters.coincheck import CoinCheckFormattedResponse
-# from bitex.formatters.cryptopia import CryptopiaFormattedResponse
-# from bitex.formatters.hitbtc import HitBTCFormattedResponse
+from bitex.formatters.binance import BinanceFormattedResponse
+from bitex.formatters.bitstamp import BitstampFormattedResponse
+from bitex.formatters.bittrex import BittrexFormattedResponse
+from bitex.formatters.ccex import CCEXFormattedResponse
+from bitex.formatters.coincheck import CoinCheckFormattedResponse
+from bitex.formatters.cryptopia import CryptopiaFormattedResponse
+from bitex.formatters.hitbtc import HitBTCFormattedResponse
 # from bitex.formatters.kraken import KrakenFormattedResponse
-# from bitex.formatters.okcoin import OkCoinFormattedResponse
+from bitex.formatters.okcoin import OKCoinFormattedResponse
 from bitex.formatters.poloniex import PoloniexFormattedResponse

--- a/bitex/formatters/base.py
+++ b/bitex/formatters/base.py
@@ -12,24 +12,46 @@ converted from the json response.
 
 class AbstractFormattedResponse(requests.Response):
 
-    def __init__(self, response_obj):
+    def __init__(self, method, response_obj, *args, **kwargs):
         self.response = response_obj
+        self.method = method
+        self.method_args = args
+        self.method_kwargs = kwargs
+
+    def __getattr__(self, attr):
+        """Use methods of the encapsulated object, otherwise use what available in the wrapper."""
+        try:
+            return getattr(self.response, attr)
+        except AttributeError:
+            return getattr(self, attr)
 
     @property
     def formatted(self):
+        """Return the formatted data, extracted from the json response."""
+        return getattr(self, self.method)
+
+    def ticker(*args, **kwargs):
         raise NotImplementedError
 
-    def __getattr__(self, attr):
-        """Use methods of the encapsulated object, when not available in the wrapper."""
-        return getattr(self.response, attr)
+    def order_book(*args, **kwargs):
+        raise NotImplementedError
+
+    def trades(*args, **kwargs):
+        raise NotImplementedError
+
+    def bid(*args, **kwargs):
+        raise NotImplementedError
+
+    def ask(*args, **kwargs):
+        raise NotImplementedError
 
 
-# Every formatter should return a tuple with the same structure, so that data can be managed in
-# the same "standard" way for every exchange.
-FormattedResponseTuple = namedtuple("FormattedResponse", ("bid",
-                                                          "ask",
-                                                          "high",
-                                                          "low",
-                                                          "last",
-                                                          "volume",
-                                                          "timestamp"))
+# Every method should return a tuple with the same structure, so that data can be managed in the
+# same "standard" way for every exchange.
+TickerFormattedResponseTuple = namedtuple("TickerResponse", ("bid",
+                                                             "ask",
+                                                             "high",
+                                                             "low",
+                                                             "last",
+                                                             "volume",
+                                                             "timestamp"))

--- a/bitex/formatters/base.py
+++ b/bitex/formatters/base.py
@@ -1,0 +1,35 @@
+"""Base class for formatters."""
+
+import requests
+from collections import namedtuple
+
+"""The base class that each formatter has to implement.
+
+It adds a `formatted` property, which returns a namedtuple with data
+converted from the json response.
+"""
+
+
+class AbstractFormattedResponse(requests.Response):
+
+    def __init__(self, response_obj):
+        self.response = response_obj
+
+    @property
+    def formatted(self):
+        raise NotImplementedError
+
+    def __getattr__(self, attr):
+        """Use methods of the encapsulated object, when not available in the wrapper."""
+        return getattr(self.response, attr)
+
+
+# Every formatter should return a tuple with the same structure, so that data can be managed in
+# the same "standard" way for every exchange.
+FormattedResponseTuple = namedtuple("FormattedResponse", ("bid",
+                                                          "ask",
+                                                          "high",
+                                                          "low",
+                                                          "last",
+                                                          "volume",
+                                                          "timestamp"))

--- a/bitex/formatters/binance.py
+++ b/bitex/formatters/binance.py
@@ -1,0 +1,20 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+
+class BinanceFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["bidPrice"]),
+                                            ask=Decimal(data["askPrice"]),
+                                            high=Decimal(data["highPrice"]),
+                                            low=Decimal(data["lowPrice"]),
+                                            last=Decimal(data["lastPrice"]),
+                                            volume=Decimal(data["volume"]),
+                                            timestamp=datetime.utcnow()
+                                            )

--- a/bitex/formatters/bitfinex.py
+++ b/bitex/formatters/bitfinex.py
@@ -1,4 +1,4 @@
-from bitex.formatters.base import AbstractFormattedResponse, FormattedResponseTuple
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
 
 from decimal import Decimal
 from datetime import datetime
@@ -9,16 +9,17 @@ fromtimestamp = datetime.fromtimestamp
 class BitfinexFormattedResponse(AbstractFormattedResponse):
 
     @property
-    def formatted(self):
+    def ticker(self):
         # {'bid': '14827.0', 'ask': '14828.0', 'high': '14961.0', 'low': '11730.0',
         #  'last_price': '14829.0', 'volume': '87898.99047435', 'timestamp': '1514042460.7861257',
         #  'mid': '14827.5'}
-        data = self.json()
-        return FormattedResponseTuple(bid=Decimal(data["bid"]),
-                                      ask=Decimal(data["ask"]),
-                                      high=Decimal(data["high"]),
-                                      low=Decimal(data["low"]),
-                                      last=Decimal(data["last_price"]),
-                                      volume=Decimal(data["volume"]),
-                                      timestamp=fromtimestamp(float(data["timestamp"]))
-                                      )
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["bid"]),
+                                            ask=Decimal(data["ask"]),
+                                            high=Decimal(data["high"]),
+                                            low=Decimal(data["low"]),
+                                            last=Decimal(data["last_price"]),
+                                            volume=Decimal(data["volume"]),
+                                            timestamp=fromtimestamp(float(data["timestamp"]))
+                                            )

--- a/bitex/formatters/bitfinex.py
+++ b/bitex/formatters/bitfinex.py
@@ -1,0 +1,24 @@
+from bitex.formatters.base import AbstractFormattedResponse, FormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+fromtimestamp = datetime.fromtimestamp
+
+
+class BitfinexFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def formatted(self):
+        # {'bid': '14827.0', 'ask': '14828.0', 'high': '14961.0', 'low': '11730.0',
+        #  'last_price': '14829.0', 'volume': '87898.99047435', 'timestamp': '1514042460.7861257',
+        #  'mid': '14827.5'}
+        data = self.json()
+        return FormattedResponseTuple(bid=Decimal(data["bid"]),
+                                      ask=Decimal(data["ask"]),
+                                      high=Decimal(data["high"]),
+                                      low=Decimal(data["low"]),
+                                      last=Decimal(data["last_price"]),
+                                      volume=Decimal(data["volume"]),
+                                      timestamp=fromtimestamp(float(data["timestamp"]))
+                                      )

--- a/bitex/formatters/bitstamp.py
+++ b/bitex/formatters/bitstamp.py
@@ -6,7 +6,7 @@ from datetime import datetime
 fromtimestamp = datetime.utcfromtimestamp
 
 
-class BitfinexFormattedResponse(AbstractFormattedResponse):
+class BitstampFormattedResponse(AbstractFormattedResponse):
 
     @property
     def ticker(self):
@@ -16,7 +16,7 @@ class BitfinexFormattedResponse(AbstractFormattedResponse):
                                             ask=Decimal(data["ask"]),
                                             high=Decimal(data["high"]),
                                             low=Decimal(data["low"]),
-                                            last=Decimal(data["last_price"]),
+                                            last=Decimal(data["last"]),
                                             volume=Decimal(data["volume"]),
                                             timestamp=fromtimestamp(Decimal(data["timestamp"]))
                                             )

--- a/bitex/formatters/bittrex.py
+++ b/bitex/formatters/bittrex.py
@@ -1,0 +1,27 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+import pytz
+
+utc = pytz.utc
+
+
+class BittrexFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+        data = data["result"][0]
+
+        dt = data["TimeStamp"]
+        curr_timestamp = utc.localize(datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%f'))
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["Bid"]),
+                                            ask=Decimal(data["Ask"]),
+                                            high=Decimal(data["High"]),
+                                            low=Decimal(data["Low"]),
+                                            last=Decimal(data["Last"]),
+                                            volume=Decimal(data["Volume"]),
+                                            timestamp=curr_timestamp,
+                                            )

--- a/bitex/formatters/ccex.py
+++ b/bitex/formatters/ccex.py
@@ -1,0 +1,30 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+fromtimestamp = datetime.utcfromtimestamp
+
+
+class CCEXFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+        data = data["ticker"]
+
+        # CCEX does not provide volume metrics.
+        # {'high': Decimal('0.00007307'), 'low': Decimal('0.00006667'),
+        #  'avg': Decimal('0.00006987'), 'lastbuy': Decimal('0.00007097'),
+        #  'lastsell': Decimal('0.00007146'), 'buy': Decimal('0.00007098'),
+        #  'sell': Decimal('0.00007145'), 'lastprice': Decimal('0.00007146'),
+        #  'buysupport': Decimal('22.39634869'), 'updated': Decimal('1515768078')}
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["lastbuy"]),
+                                            ask=Decimal(data["lastsell"]),
+                                            high=Decimal(data["high"]),
+                                            low=Decimal(data["low"]),
+                                            last=Decimal(data["lastprice"]),
+                                            volume=None,
+                                            timestamp=fromtimestamp(Decimal(data["updated"]))
+                                            )

--- a/bitex/formatters/coincheck.py
+++ b/bitex/formatters/coincheck.py
@@ -6,7 +6,7 @@ from datetime import datetime
 fromtimestamp = datetime.utcfromtimestamp
 
 
-class BitfinexFormattedResponse(AbstractFormattedResponse):
+class CoinCheckFormattedResponse(AbstractFormattedResponse):
 
     @property
     def ticker(self):
@@ -16,7 +16,7 @@ class BitfinexFormattedResponse(AbstractFormattedResponse):
                                             ask=Decimal(data["ask"]),
                                             high=Decimal(data["high"]),
                                             low=Decimal(data["low"]),
-                                            last=Decimal(data["last_price"]),
+                                            last=Decimal(data["last"]),
                                             volume=Decimal(data["volume"]),
                                             timestamp=fromtimestamp(Decimal(data["timestamp"]))
                                             )

--- a/bitex/formatters/cryptopia.py
+++ b/bitex/formatters/cryptopia.py
@@ -1,0 +1,21 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+
+class CryptopiaFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+        data = data["Data"]
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["BidPrice"]),
+                                            ask=Decimal(data["AskPrice"]),
+                                            high=Decimal(data["High"]),
+                                            low=Decimal(data["Low"]),
+                                            last=Decimal(data["LastPrice"]),
+                                            volume=Decimal(data["Volume"]),
+                                            timestamp=datetime.utcnow()
+                                            )

--- a/bitex/formatters/hitbtc.py
+++ b/bitex/formatters/hitbtc.py
@@ -6,17 +6,19 @@ from datetime import datetime
 fromtimestamp = datetime.utcfromtimestamp
 
 
-class BitfinexFormattedResponse(AbstractFormattedResponse):
+class HitBTCFormattedResponse(AbstractFormattedResponse):
 
     @property
     def ticker(self):
         data = self.json(parse_int=Decimal, parse_float=Decimal)
 
+        curr_timestamp = fromtimestamp(data["timestamp"] / Decimal(1000))
+
         return TickerFormattedResponseTuple(bid=Decimal(data["bid"]),
                                             ask=Decimal(data["ask"]),
                                             high=Decimal(data["high"]),
                                             low=Decimal(data["low"]),
-                                            last=Decimal(data["last_price"]),
+                                            last=Decimal(data["last"]),
                                             volume=Decimal(data["volume"]),
-                                            timestamp=fromtimestamp(Decimal(data["timestamp"]))
+                                            timestamp=curr_timestamp,
                                             )

--- a/bitex/formatters/kraken.py
+++ b/bitex/formatters/kraken.py
@@ -1,0 +1,20 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+
+
+class KrakenFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+
+        # return TickerFormattedResponseTuple(bid=Decimal(data["bid"]),
+        #                                     ask=Decimal(data["ask"]),
+        #                                     high=Decimal(data["high"]),
+        #                                     low=Decimal(data["low"]),
+        #                                     last=Decimal(data["last"]),
+        #                                     volume=Decimal(data["volume"]),
+        #                                     timestamp=data["timestamp"] / Decimal(1000),
+        #                                     )
+        raise NotImplementedError

--- a/bitex/formatters/okcoin.py
+++ b/bitex/formatters/okcoin.py
@@ -1,0 +1,22 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+fromtimestamp = datetime.utcfromtimestamp
+
+
+class OKCoinFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self):
+        data = self.json(parse_int=Decimal, parse_float=Decimal)
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["ticker"]["buy"]),
+                                            ask=Decimal(data["ticker"]["sell"]),
+                                            high=Decimal(data["ticker"]["high"]),
+                                            low=Decimal(data["ticker"]["low"]),
+                                            last=Decimal(data["ticker"]["last"]),
+                                            volume=Decimal(data["ticker"]["vol"]),
+                                            timestamp=fromtimestamp(Decimal(data["date"])),
+                                            )

--- a/bitex/formatters/poloniex.py
+++ b/bitex/formatters/poloniex.py
@@ -3,8 +3,6 @@ from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResp
 from decimal import Decimal
 from datetime import datetime
 
-# fromtimestamp = datetime.fromtimestamp
-
 
 class PoloniexFormattedResponse(AbstractFormattedResponse):
 

--- a/bitex/formatters/poloniex.py
+++ b/bitex/formatters/poloniex.py
@@ -1,0 +1,29 @@
+from bitex.formatters.base import AbstractFormattedResponse, TickerFormattedResponseTuple
+
+from decimal import Decimal
+from datetime import datetime
+
+# fromtimestamp = datetime.fromtimestamp
+
+
+class PoloniexFormattedResponse(AbstractFormattedResponse):
+
+    @property
+    def ticker(self, *args, **kwargs):
+
+        # The Poloniex public ticker returns a json containing the ticker of all the pairs traded
+        # on the exchange. This is why we had to store the arguments passed to the method (ticker,
+        # ask, etc..) of the Poloniex class, in order to extract the pair the user wants, and
+        # format it in the correct way.
+        all_pairs_tickers = self.json(parse_int=Decimal, parse_float=Decimal)
+        _, pair_requested = self.method_args[:2]
+        data = all_pairs_tickers[pair_requested]
+
+        return TickerFormattedResponseTuple(bid=Decimal(data["highestBid"]),
+                                            ask=Decimal(data["lowestAsk"]),
+                                            high=Decimal(data["high24hr"]),
+                                            low=Decimal(data["low24hr"]),
+                                            last=Decimal(data["last"]),
+                                            volume=Decimal(data["quoteVolume"]),
+                                            timestamp=datetime.utcnow()
+                                            )

--- a/bitex/interface/binance.py
+++ b/bitex/interface/binance.py
@@ -5,6 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.binance import BinanceREST
 from bitex.interface.rest import RESTInterface
+from bitex.utils import format_with
+from bitex.formatters import BinanceFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -34,6 +36,7 @@ class Binance(RESTInterface):
         pairs = [entry['symbol'] for entry in r['symbols']]
         return pairs
 
+    @format_with(BinanceFormattedResponse)
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""
         payload = {'symbol': pair}

--- a/bitex/interface/bitfinex.py
+++ b/bitex/interface/bitfinex.py
@@ -42,11 +42,11 @@ class Bitfinex(RESTInterface):
                        'lends', 'funding_book']
 
     def __init__(self, **api_kwargs):
-        """Initialize class instance."""
+        """Initialize Interface class instance."""
         super(Bitfinex, self).__init__('Bitfinex', BitfinexREST(**api_kwargs))
 
     def request(self, endpoint, authenticate=False, **req_kwargs):
-        """Preprocess request to API."""
+        """Generate a request to the API."""
         if not authenticate:
             return super(Bitfinex, self).request('GET', endpoint, authenticate=authenticate,
                                                  **req_kwargs)

--- a/bitex/interface/bitfinex.py
+++ b/bitex/interface/bitfinex.py
@@ -8,7 +8,8 @@ import requests
 # Import Homebrew
 from bitex.api.REST.bitfinex import BitfinexREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_version_compatibility, check_and_format_pair
+from bitex.utils import check_version_compatibility, check_and_format_pair, format_with
+from bitex.formatters import BitfinexFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -61,6 +62,8 @@ class Bitfinex(RESTInterface):
     ###############
     # Basic Methods
     ###############
+
+    @format_with(BitfinexFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, **endpoint_kwargs):
         """Return the ticker for a given pair."""

--- a/bitex/interface/bitstamp.py
+++ b/bitex/interface/bitstamp.py
@@ -7,7 +7,9 @@ import logging
 from bitex.exceptions import UnsupportedPairError
 from bitex.api.REST.bitstamp import BitstampREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import BitstampFormattedResponse
+
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -39,6 +41,7 @@ class Bitstamp(RESTInterface):
     ###############
 
     # Public Endpoints
+    @format_with(BitstampFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/bittrex.py
+++ b/bitex/interface/bittrex.py
@@ -6,7 +6,8 @@ import logging
 from bitex.api.REST.bittrex import BittrexREST
 
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import BittrexFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class Bittrex(RESTInterface):
     ###############
     # Basic Methods
     ###############
+    @format_with(BittrexFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/ccex.py
+++ b/bitex/interface/ccex.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.ccex import CCEXREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import CCEXFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ class CCEX(RESTInterface):
         return self.request('/pairs.json').json()['pairs']
 
     # Public Endpoints
+    @format_with(CCEXFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/coincheck.py
+++ b/bitex/interface/coincheck.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.coincheck import CoincheckREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import CoinCheckFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class CoinCheck(RESTInterface):
         return ['btc-jpy']
 
     # Public Endpoints
+    @format_with(CoinCheckFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/cryptopia.py
+++ b/bitex/interface/cryptopia.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.cryptopia import CryptopiaREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import CryptopiaFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -24,6 +25,7 @@ class Cryptopia(RESTInterface):
         return pairs
 
     # Public Endpoints
+    @format_with(CryptopiaFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/hitbtc.py
+++ b/bitex/interface/hitbtc.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.hitbtc import HitBTCREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import HitBTCFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class HitBTC(RESTInterface):
                                            **req_kwargs)
 
     # Public Endpoints
+    @format_with(HitBTCFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/kraken.py
+++ b/bitex/interface/kraken.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.kraken import KrakenREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+# from bitex.formatters import KrakenFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class Kraken(RESTInterface):
 
     # Public Endpoints
     # pylint: disable=arguments-differ
+    # @format_with(KrakenFormattedResponse)
     @check_and_format_pair
     def ticker(self, *pairs, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/okcoin.py
+++ b/bitex/interface/okcoin.py
@@ -5,7 +5,8 @@ import logging
 # Import Homebrew
 from bitex.api.REST.okcoin import OKCoinREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import OKCoinFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ class OKCoin(RESTInterface):
                 'btc_cny', 'ltc_cny', 'eth_cny']
 
     # Public Endpoints
+    @format_with(OKCoinFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/interface/poloniex.py
+++ b/bitex/interface/poloniex.py
@@ -5,14 +5,19 @@ import logging
 # Import Homebrew
 from bitex.api.REST.poloniex import PoloniexREST
 from bitex.interface.rest import RESTInterface
-from bitex.utils import check_and_format_pair
+from bitex.utils import check_and_format_pair, format_with
+from bitex.formatters import PoloniexFormattedResponse
 
 # Init Logging Facilities
 log = logging.getLogger(__name__)
 
 
 class Poloniex(RESTInterface):
-    """Poloniex Interface class."""
+    """Poloniex Interface class.
+
+    Includes standardized methods, as well as all other Endpoints
+    available on their REST API.
+    """
 
     def __init__(self, **api_kwargs):
         """Initialize Interface class instance."""
@@ -35,6 +40,7 @@ class Poloniex(RESTInterface):
         return ['BTC_ETH']
 
     # Public Endpoints
+    @format_with(PoloniexFormattedResponse)
     @check_and_format_pair
     def ticker(self, pair, *args, **kwargs):
         """Return the ticker for the given pair."""

--- a/bitex/utils.py
+++ b/bitex/utils.py
@@ -76,13 +76,13 @@ def load_configuration(fname):
 
 # The following is a decorator which accepts a parameter, which should be a class that encapsulate
 # a response and add useful methods, such as formatter.
-def format_with(class_to_use):
+def format_with(formatter):
     """Pass a class to be used as a wrapper in the innermost function."""
-    def real_decorator(function):
 
+    def real_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            return class_to_use(function(*args, **kwargs))
+            return formatter(function.__name__, function(*args, **kwargs), *args, **kwargs)
 
         return wrapper
 

--- a/bitex/utils.py
+++ b/bitex/utils.py
@@ -72,3 +72,18 @@ def load_configuration(fname):
     config = configparser.ConfigParser()
     config.read(fname)
     return config
+
+
+# The following is a decorator which accepts a parameter, which should be a class that encapsulate
+# a response and add useful methods, such as formatter.
+def format_with(class_to_use):
+    """Pass a class to be used as a wrapper in the innermost function."""
+    def real_decorator(function):
+
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            return class_to_use(function(*args, **kwargs))
+
+        return wrapper
+
+    return real_decorator


### PR DESCRIPTION
Implementation of formatters (issue #129) using containment and delegation instead of inheritance.
The key is in the `__getattr__` method of the AbstractFormattedResponse (`bitex/formatters/base.py`).

Usage example:
```
>>> from bitex import Bitfinex
>>> resp = Bitfinex().ticker("btcusd")
>>> resp.formatted
FormattedResponse(bid=Decimal('14661.0'), ask=Decimal('14676.0'), high=Decimal('14961.0'), low=Decimal('11730.0'), last=Decimal('14661.0'), volume=Decimal('85803.14989423'), timestamp=datetime.datetime(2017, 12, 23, 16, 40, 51, 487780))
```