### PR TITLE
Fix KrakenFormattedResponse.ticker()

### DIFF
--- a/bitex/formatters/kraken.py
+++ b/bitex/formatters/kraken.py
@@ -16,7 +16,7 @@ class KrakenFormattedResponse(APIResponse):
 
     def ticker(self):
         """Return namedtuple with given data."""
-        pair = self.method_args[0]
+        pair = self.method_args[1]
         data = self.json(parse_int=str, parse_float=str)['result'][pair]
         bid = data["b"][0]
         ask = data["a"][0]


### PR DESCRIPTION
self.method_args[0] refers to a bitex.interface.kraken.Kraken object,
self.method_args[1] refers to the pair symbol. Update index for
accessing pair from 0 to 1.

Without this fix, running the following code:
```python
import bitex
kraken = bitex.Kraken()
ticker_kraken = kraken.ticker(bitex.ETHUSD).ticker()
```
will result in the following exception:
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    ticker_kraken = kraken.ticker(bitex.ETHUSD).ticker()
  File "/usr/local/lib/python3.6/site-packages/bitex/formatters/kraken.py", line 20, in ticker
    data = self.json(parse_int=str, parse_float=str)['result'][pair]
KeyError: <bitex.interface.kraken.Kraken object at 0x108d7c4a8>
```