### PR TITLE
Fix several bitstamp API issues

### DIFF
--- a/bitex/api/REST/bitstamp.py
+++ b/bitex/api/REST/bitstamp.py
@@ -74,7 +74,7 @@ class BitstampREST(RESTAPI):
         params['nonce'] = nonce
         params['signature'] = signature
         req_kwargs['data'] = params or req_kwargs['data']
-        if endpoint.startswith('api'):
-            req_kwargs['url'] = self.addr + '/' + endpoint
+        if endpoint.startswith('api/'):
+            req_kwargs['url'] = self.addr + '/' + endpoint.lstrip('api/')
 
         return req_kwargs

--- a/bitex/interface/bitstamp.py
+++ b/bitex/interface/bitstamp.py
@@ -6,7 +6,6 @@ import logging
 import requests
 
 # Import Homebrew
-from bitex.exceptions import UnsupportedPairError
 from bitex.api.REST.bitstamp import BitstampREST
 from bitex.interface.rest import RESTInterface
 from bitex.utils import check_and_format_pair, format_with
@@ -77,101 +76,97 @@ class Bitstamp(RESTInterface):
 
     def _place_order(self, pair, price, size, side, market=None, **kwargs):
         """Place an order with the given parameters."""
-        payload = {'amount': size, 'price': price}
-        payload.update(kwargs)
-        if market:
-            return self.request('%s/market/%s/' % (side, pair), authenticate=True, params=payload)
-        return self.request('%s/%s/' % (side, pair), authenticate=True, params=payload)
+        kwargs.update({'amount': size, 'price': price})
+        suffix = 'market/' if market else ''
+        return self.request('%s/%s%s/' % (side, suffix, pair), authenticate=True, params=kwargs)
 
     @format_with(BitstampFormattedResponse)
     def order_status(self, order_id, *args, **kwargs):
         """Return the order status for the given order's ID."""
-        payload = {'id': order_id}
-        payload.update(kwargs)
-        return self.request('api/order_status/', authenticate=True, params=payload)
+        kwargs.update({'id': order_id})
+        return self.request('api/order_status/', authenticate=True, params=kwargs)
 
     @format_with(BitstampFormattedResponse)
     def open_orders(self, *args, pair=None, **kwargs):
         """Return all open orders."""
-        if pair:
-            return self.request('open_orders/%s/' % pair, authenticate=True, params=kwargs)
-        return self.request('open_orders/all/', authenticate=True, params=kwargs)
+        suffix = pair or 'all'
+        return self.request('open_orders/%s/' % suffix, authenticate=True, params=kwargs)
 
     @format_with(BitstampFormattedResponse)
     def cancel_order(self, *order_ids, **kwargs):
         """Cancel existing order(s) with the given id(s)."""
         results = []
-        payload = kwargs
         for oid in order_ids:
-            payload.update({'id': oid})
-            r = self.request('cancel_order/', authenticate=True, params=payload)
+            kwargs.update({'id': oid})
+            r = self.request('cancel_order/', authenticate=True, params=kwargs)
             results.append(r)
         return results if len(results) > 1 else results[0]
 
     @format_with(BitstampFormattedResponse)
-    def wallet(self, *args, **kwargs):
+    def wallet(self, *args, pair=None, **kwargs):
         """Return account's wallet."""
-        if 'pair' in kwargs:
+        endpoint = 'balance/'
+        if pair:
             try:
-                pair = kwargs['pair'].format_for(self.name).lower()
+                pair = pair.format_for(self.name).lower()
             except AttributeError:
-                pair = kwargs['pair']
-
-            return self.request('balance/%s/' % pair, authenticate=True, params=kwargs)
-        return self.request('balance/', authenticate=True, params=kwargs)
+                pass
+            endpoint += pair + '/'
+        return self.request(endpoint, authenticate=True, params=kwargs)
 
     ###########################
     # Exchange Specific Methods
     ###########################
 
     @check_and_format_pair
-    def hourly_ticker(self, pair, **kwargs):
+    def hourly_ticker(self, pair):
         """Return the hourly ticker for the given pair."""
-        if pair:
-            return self.request('ticker_hour/%s/' % pair, params=kwargs)
-        return self.request('api/ticker_hour/')
+        return self.request('ticker_hour/' + pair)
 
-    def eur_usd_conversion_rate(self, **kwargs):
+    def eur_usd_conversion_rate(self):
         """Return EUR/USD conversion rate."""
-        return self.request('api/eur_usd/', params=kwargs)
+        return self.request('api/eur_usd/')
 
-    @check_and_format_pair
-    def user_transactions(self, pair, **kwargs):
+    def user_transactions(self, pair=None, **kwargs):
         """Return user transactions."""
+        endpoint = 'user_transactions/'
         if pair:
-            return self.request('user_transactions/%s/' % pair, authenticate=True, params=kwargs)
-        return self.request('api/user_transactions/', authenticate=True, params=kwargs)
+            try:
+                pair = pair.format_for(self.name).lower()
+            except AttributeError:
+                pass
+            endpoint += pair + '/'
+        return self.request(endpoint, authenticate=True, params=kwargs)
 
-    def cancel_all_orders(self, **kwargs):
+    def cancel_all_orders(self):
         """Cancel all orders."""
-        return self.request('api/cancel_all_orders/', authenticate=True, params=kwargs)
+        return self.request('cancel_all_orders/', authenticate=True)
 
-    def withdrawal_request(self, **kwargs):
-        """Issue a withdrawal request."""
-        return self.request('api/withdrawal_request', authenticate=True, params=kwargs)
-
-    def withdraw(self, currency, **kwargs):  # pylint: disable=unused-argument
+    def withdraw(self, currency, **kwargs):
         """Withdraw currency from the account."""
-        if currency in ('LTC', 'ltc'):
-            return self.request('ltc_withdrawal', authenticate=True)
-        elif currency in ('BTC', 'btc'):
-            return self.request('api/bitcoin_widthdrawal', authenticate=True)
-        elif currency in ('XRP', 'xrp'):
-            return self.request('xrp_withdrawal/', authenticate=True)
+        currency = currency.lower()
+        if currency == 'btc':
+            endpoint = 'api/bitcoin_withdrawal/'
+        elif currency == 'xrp':
+            endpoint = 'api/ripple_withdrawal/'
         else:
-            raise UnsupportedPairError('Currency must be LTC/ltc,'
-                                       'BTC/btc or XRP/xrp!')
+            endpoint = '%s_withdrawal/' % currency
+        return self.request(endpoint, authenticate=True, params=kwargs)
+
+    def withdrawal_requests(self, **kwargs):
+        """Returns user withdrawal requests."""
+        return self.request('withdrawal-requests/', authenticate=True, params=kwargs)
 
     def deposit_address(self, currency):
         """Return the currency's deposit address."""
-        if currency in ('LTC', 'ltc'):
-            return self.request('ltc_address/', authenticate=True)
-        elif currency in ('BTC', 'btc'):
-            return self.request('api/bitcoin_deposit_address', authenticate=True)
-        elif currency in ('XRP', 'xrp'):
-            return self.request('xrp_address/', authenticate=True)
+        currency = currency.lower()
+        if currency == 'btc':
+            endpoint = 'api/bitcoin_deposit_address/'
+        elif currency == 'xrp':
+            endpoint = 'api/ripple_address/'
         else:
-            raise UnsupportedPairError('Currency must be LTC/ltc or BTC/btc!')
+            endpoint = '%s_address/' % currency
+        return self.request(endpoint, authenticate=True)
 
     def unconfirmed_bitcoin_deposits(self):
         """Return all unconfirmed bitcoin deposits."""
@@ -179,13 +174,11 @@ class Bitstamp(RESTInterface):
 
     def transfer_sub_to_main(self, **kwargs):
         """Transfer currency from sub account to main."""
-        return self.request('transfer_to_main/', authenticate=True,
-                            params=kwargs)
+        return self.request('transfer-to-main/', authenticate=True, params=kwargs)
 
     def transfer_main_to_sub(self, **kwargs):
         """Transfer currency from main account to sub account."""
-        return self.request('transfer_from_main/', authenticate=True,
-                            params=kwargs)
+        return self.request('transfer-from-main/', authenticate=True, params=kwargs)
 
     def open_bank_withdrawal(self, **kwargs):
         """Issue a bank withdrawal."""
@@ -193,20 +186,16 @@ class Bitstamp(RESTInterface):
 
     def bank_withdrawal_status(self, **kwargs):
         """Query status of a bank withdrawal."""
-        return self.request('withdrawal/status/', authenticate=True,
-                            params=kwargs)
+        return self.request('withdrawal/status/', authenticate=True, params=kwargs)
 
     def cancel_bank_withdrawal(self, **kwargs):
         """Cancel a bank withdrawal."""
-        return self.request('withdrawal/cancel/', authenticate=True,
-                            params=kwargs)
+        return self.request('withdrawal/cancel/', authenticate=True, params=kwargs)
 
     def liquidate(self, **kwargs):
         """Liquidate all assets."""
-        return self.request('liquidation_address/new/', authenticate=True,
-                            params=kwargs)
+        return self.request('liquidation_address/new/', authenticate=True, params=kwargs)
 
     def liquidation_info(self, **kwargs):
         """Return liquidity information."""
-        return self.request('liquidation_address/info/', authenticate=True,
-                            params=kwargs)
+        return self.request('liquidation_address/info/', authenticate=True, params=kwargs)


### PR DESCRIPTION
Fix calls to endpoints beginning with "api/".
Allow to get all user_transactions at once (pair is optional!).
Allow to get deposit address and to withdraw BCH.
Add missing withdrawal_requests method.
Remove inexistent withdrawal_request method (withdraw exists already).
Fix transfer_sub_to_main and transfer_main_to_sub endpoints.
Various DRY-ups, clean-ups, code style improvements.